### PR TITLE
Update extension displayName to MicroProfile Tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-microprofile",
-  "displayName": "MicroProfile Language Support",
-  "description": "MicroProfile Language Support for Visual Studio Code",
+  "displayName": "MicroProfile Tools",
+  "description": "MicroProfile Tools for Visual Studio Code",
   "version": "0.1.0",
   "icon": "icons/logo.png",
   "author": "Red Hat",
@@ -18,6 +18,7 @@
   },
   "categories": [
     "Programming Languages",
+    "Snippets",
     "Other"
   ],
   "repository": {


### PR DESCRIPTION
Updates `displayName` and `description` in package.json to `MicroProfile Tools` to match the name used in changelog/extension settings/messages 

Also adds `Snippets` to categories since lsp4mp provides microprofile snippets.
 
Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>