### PR TITLE
Detect lightweight java language server

### DIFF
--- a/src/util/javaServerMode.ts
+++ b/src/util/javaServerMode.ts
@@ -1,0 +1,59 @@
+import { extensions, window, commands } from "vscode";
+
+const JAVA_EXTENSION_ID = "redhat.java";
+
+export enum ServerMode {
+  STANDARD = "Standard",
+  LIGHTWEIGHT = "LightWeight",
+  HYBRID = "Hybrid",
+}
+
+/**
+ * Waits for the java language server to launch in standard mode
+ * Before activating MicroProfile tools.
+ * If java ls was started in lightweight mode, It will prompt user to switch
+ */
+export async function waitForStandardMode() {
+  const vscodeJava = extensions.getExtension(JAVA_EXTENSION_ID);
+  if (!vscodeJava) {
+    throw new Error("VSCode java is not installed");
+  }
+
+  const api = await vscodeJava.activate();
+  if (!api) {
+    throw new Error("VSCode java api not found");
+  }
+
+  // If hybrid, standard mode is being launched. Wait for standard mode then resolve.
+  if (api.serverMode === ServerMode.HYBRID) {
+    return new Promise((resolve) => {
+      api.onDidServerModeChange((mode: string) => {
+        if (mode === ServerMode.STANDARD) {
+          resolve();
+        }
+      });
+    });
+    // If Lightweight. Prompt to switch then wait for Standard mode.
+    // Even if they do not select Yes on the prompt. This still waits for standard mode
+    // since standard mode switch can be triggered other ways.
+  } else if (api.serverMode === ServerMode.LIGHTWEIGHT) {
+    window.showInformationMessage(
+        `MicroProfile Tools requires the Java language server to run in Standard mode.` +
+        "Do you want to switch it to Standard mode now?",
+        "Yes",
+        "Later"
+      )
+      .then((answer) => {
+        if (answer === "Yes") {
+          commands.executeCommand("java.server.mode.switch", ServerMode.STANDARD, true);
+        }
+      });
+    return new Promise((resolve) => {
+      api.onDidServerModeChange((mode: string) => {
+        if (mode === ServerMode.STANDARD) {
+          resolve();
+        }
+      });
+    });
+  }
+}


### PR DESCRIPTION
Fixes #12 

Detects if java ls started in lightweight mode and prompts user to switch to standard. The user ends up getting a second prompt from vscode-java to ask if they are sure.

<img width="483" alt="Screen Shot 2020-08-06 at 11 06 31 AM" src="https://user-images.githubusercontent.com/16768710/89548375-f31ca200-d7d4-11ea-8c52-30b1256b028f.png">
<img width="481" alt="Screen Shot 2020-08-06 at 10 53 27 AM" src="https://user-images.githubusercontent.com/16768710/89547384-ae443b80-d7d3-11ea-9070-ba13a63cd557.png">

