### PR TITLE
Add new setting for property expression validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Default is `warning`.
 Default is `error`.
 * `microprofile.tools.validation.required.severity` : Validation severity for required properties for MicroProfile `*.properties` files.
 Default is `none`.
+* `microprofile.tools.validation.expression.severity` : Validation severity for property expressions for MicroProfile `*.properties` files.
+Default is `error`.
 * `microprofile.tools.validation.unknown.severity` : Validation severity for unknown properties for MicroProfile `*.properties` files. Default is `warning`.
 * `microprofile.tools.validation.unknown.excluded` : Array of properties to ignore for unknown properties validation. Patterns can be used ('*' = any string, '?' = any character).
 Default is `["*/mp-rest/providers/*/priority", "mp.openapi.schema.*"]`.

--- a/package.json
+++ b/package.json
@@ -161,6 +161,17 @@
           "markdownDescription": "Validation severity for property values for MicroProfile `*.properties` files.",
           "scope": "window"
         },
+        "microprofile.tools.validation.expression.severity": {
+          "type": "string",
+          "enum": [
+            "none",
+            "warning",
+            "error"
+          ],
+          "default": "error",
+          "markdownDescription": "Validation severity for property expressions for MicroProfile `*.properties` files.",
+          "scope": "window"
+        },
         "microprofile.tools.validation.unknown.excluded": {
           "type": "array",
           "default": [


### PR DESCRIPTION
You can now set the severity of diagnostics related to references to unknown properties using `microprofile.tools.validation.expression.severity`.

Requires the server-side changes in https://github.com/eclipse/lsp4mp/pull/21

Signed-off-by: David Thompson <davthomp@redhat.com>