### PR TITLE
Ignore kafka-streams namespace by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Default is `none`.
 Default is `error`.
 * `microprofile.tools.validation.unknown.severity` : Validation severity for unknown properties for MicroProfile `*.properties` files. Default is `warning`.
 * `microprofile.tools.validation.unknown.excluded` : Array of properties to ignore for unknown properties validation. Patterns can be used ('*' = any string, '?' = any character).
-Default is `["*/mp-rest/providers/*/priority", "mp.openapi.schema.*"]`.
+Default is `["*/mp-rest/providers/*/priority", "mp.openapi.schema.*", "kafka-streams.*"]`.
 * `microprofile.tools.codeLens.urlCodeLensEnabled` : Enable/disable the URL code lenses for REST services. Default is`true`.
 * `microprofile.tools.validation.value.severity`: Validation severity for property values for MicroProfile `*.properties` files. Default is `error`.
 

--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
           "type": "array",
           "default": [
             "*/mp-rest/providers/*/priority",
-            "mp.openapi.schema.*"
+            "mp.openapi.schema.*",
+            "kafka-streams.*"
           ],
           "items": {
             "type": "string"


### PR DESCRIPTION
- Resolves redhat-developer/vscode-quarkus#314 

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

I'll need to test this out to confirm it works correctly, but this seems to be the right thing.