### PR TITLE
Directly consume the completion from the jdt.ls extension

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,20 +1,26 @@
 {
-    "env": {
-        "es2021": true,
-        "node": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-    }
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_"
+      }
+    ]
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,12 +21,13 @@ import { prepareExecutable } from './languageServer/javaServerStarter';
 import { collectMicroProfileJavaExtensions, handleExtensionChange, MicroProfileContribution } from './languageServer/plugin';
 import * as requirements from './languageServer/requirements';
 import { CommandKind, registerConfigurationUpdateCommand, registerOpenURICommand } from './lsp-commands';
+import { registerProviders } from './providers/microProfileProviders';
 import { waitForStandardMode } from './util/javaServerMode';
 import { MicroProfilePropertiesChangeEvent, registerYamlSchemaSupport } from './yaml/YamlSchema';
 
 let languageClient: LanguageClient;
 
-export async function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext): Promise<void> {
 
   const telemetryService: TelemetryService = await getTelemetryService("redhat.vscode-microprofile");
   await telemetryService.sendStartupEvent();
@@ -82,9 +83,11 @@ export async function activate(context: ExtensionContext) {
   }
 
   registerVSCodeCommands(context);
+  registerProviders();
+
 }
 
-export async function deactivate() {
+export async function deactivate(): Promise<void> {
   // language client may not have been started
   // if java language server was never launched in standard mode.
   if (languageClient) {
@@ -116,6 +119,9 @@ function connectToLS(context: ExtensionContext) {
                 CommandKind.COMMAND_OPEN_URI
               ]
             }
+          },
+          completion: {
+            skipSendingJavaCompletionThroughLanguageServer: true
           }
         }
       },

--- a/src/providers/microProfileCompletionItemProvider.ts
+++ b/src/providers/microProfileCompletionItemProvider.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CancellationToken, commands, CompletionContext, CompletionItem, CompletionItemProvider, CompletionList, Position, ProviderResult, TextDocument } from "vscode";
+import { JAVA_COMPLETION_REQUEST } from "../definitions/microProfileLSRequestNames";
+
+/**
+ * Provides context-aware completion suggestions for Java files in MicroProfile projects
+ */
+export class MicroProfileCompletionItemProvider implements CompletionItemProvider<CompletionItem> {
+
+  provideCompletionItems(
+      document: TextDocument,
+      position: Position,
+      _token: CancellationToken,
+      _context: CompletionContext): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
+    return commands.executeCommand("java.execute.workspaceCommand", JAVA_COMPLETION_REQUEST, adaptToMicroProfileCompletionParams(document, position));
+  }
+
+}
+
+function adaptToMicroProfileCompletionParams(document: TextDocument, position: Position): MicroProfileCompletionParams {
+  return {
+    uri: document.uri.toString(),
+    position: position
+  }
+}
+
+interface MicroProfileCompletionParams {
+  uri: string;
+  position: Position;
+}

--- a/src/providers/microProfileProviders.ts
+++ b/src/providers/microProfileProviders.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { languages } from "vscode";
+import { MicroProfileCompletionItemProvider } from "./microProfileCompletionItemProvider";
+
+/**
+ * Register language feature providers that are not provided directly by lsp4mp
+ */
+export function registerProviders(): void {
+  languages.registerCompletionItemProvider('java', new MicroProfileCompletionItemProvider(), //
+      "\"");
+}


### PR DESCRIPTION
Improve the performance for completion in java files by directly consuming the output of the jdt.ls extension, instead of having the requests and results forwarded through the MicroProfile language server.

See eclipse/lsp4mp#129

Signed-off-by: David Thompson <davthomp@redhat.com>
