### PR TITLE
Export an API to indicate when lsp4mp has started

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -1,0 +1,23 @@
+{
+  "Copyright Header": {
+    "scope": "javascript,typescript",
+    "prefix": "copyright",
+    "body": [
+      "/**",
+      " * Copyright ${CURRENT_YEAR} ${1:Red Hat, Inc.} and others.",
+      " *",
+      " * Licensed under the Apache License, Version 2.0 (the \"License\");",
+      " * you may not use this file except in compliance with the License.",
+      " * You may obtain a copy of the License at",
+      " *",
+      " *     http://www.apache.org/licenses/LICENSE-2.0",
+      " *",
+      " * Unless required by applicable law or agreed to in writing, software",
+      " * distributed under the License is distributed on an \"AS IS\" BASIS,",
+      " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+      " * See the License for the specific language governing permissions and",
+      " * limitations under the License.",
+      " */"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
     "onLanguage:java"
   ],
   "main": "./dist/extension",
-  "extensionDependencies": [
-    "redhat.java"
-  ],
+  "extensionDependencies": [],
   "contributes": {
     "javaExtensions": [
       "./jars/org.eclipse.lsp4mp.jdt.core.jar"

--- a/src/api/toolsForMicroProfileAPI.ts
+++ b/src/api/toolsForMicroProfileAPI.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ToolsForMicroProfileAPI {
+
+  /**
+   * Returns when the language server is ready
+   *
+   * @returns when the language server is ready
+   */
+  languageServerReady(): Promise<void>;
+
+}

--- a/src/api/toolsForMicroProfileAPIImpl.ts
+++ b/src/api/toolsForMicroProfileAPIImpl.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ToolsForMicroProfileAPI } from "./toolsForMicroProfileAPI";
+
+export class ToolsForMicroProfileAPIImpl implements ToolsForMicroProfileAPI {
+
+  private languageServerStarted: Promise<unknown>
+
+  constructor(languageServerStarted: Promise<unknown>) {
+    this.languageServerStarted = languageServerStarted;
+  }
+
+  async languageServerReady(): Promise<void> {
+    await this.languageServerStarted;
+  }
+
+}

--- a/src/util/javaServerMode.ts
+++ b/src/util/javaServerMode.ts
@@ -16,7 +16,7 @@ export enum ServerMode {
 export async function waitForStandardMode(): Promise<void>  {
   const vscodeJava = extensions.getExtension(JAVA_EXTENSION_ID);
   if (!vscodeJava) {
-    throw new Error("VSCode java is not installed");
+    await promptToInstallJava();
   }
 
   const api = await vscodeJava.activate();
@@ -55,5 +55,16 @@ export async function waitForStandardMode(): Promise<void>  {
         }
       });
     });
+  }
+}
+
+async function promptToInstallJava(): Promise<void> {
+  const YES = 'Install vscode-java';
+  const NO = 'Don\'t install';
+  const choice = await window.showErrorMessage("vscode-java is needed in order for vscode-microprofile to work. Install it now?", YES, NO);
+  if (choice === YES) {
+    await commands.executeCommand('workbench.extensions.installExtension', JAVA_EXTENSION_ID);
+  } else {
+    throw new Error("vscode-microprofile cannot work without vscode-java installed");
   }
 }


### PR DESCRIPTION
Instead of returning from activate when lsp4mp has started, return before it has started. This allows extensions that depend on vscode-microprofile to begin activating before lsp4mp has fully started. Return an API that provides a promise which resolves once lsp4mp has started, so that extensions that need to interact with lsp4mp can wait until it is ready.

Signed-off-by: David Thompson <davthomp@redhat.com>
