### PR TITLE
Use vsce 1.x since 2.x is not compatible with Node 12.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: Install build tools
-        run: npm i -g vsce
+        run: npm i -g vsce@1.103.1
       - name: Install dependencies
         run: npm i
       - name: Compile extension

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node('rhel8'){
     stage('Install requirements') {
         def nodeHome = tool 'nodejs-12.13.1'
         env.PATH="${env.PATH}:${nodeHome}/bin"
-        sh "npm install -g typescript vsce"
+        sh 'npm install -g typescript "vsce@<2"'
     }
 
     stage('Build') {


### PR DESCRIPTION
```
+npm WARN notsup Unsupported engine for vsce@2.1.0: wanted: {"node":">= 14"} (current: {"node":"12.13.1","npm":"6.12.1"})
+npm WARN notsup Not compatible with your version of node/npm: vsce@2.1.0
+
++ vsce@2.1.0
```

Note : In the GH actions yaml, I went with `@1.103.1` instead of `@<2` because we also run the build on Windows and PowerShell doesn't seem to support that format. There might be some special way to escape it so it works but for now we can just list the value as-is.

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>