### PR TITLE
Use embedded JRE from redhat.java to launch language server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ In `Java` files, you will benefit with:
 
 ## Requirements
 
-  * Java JDK (or JRE) 11 or more recent
   * [Language Support for Java(TM) by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java)
+  * Java JDK (or JRE) 11 or more recent is required **except** on the following platforms : `win32-x64`, `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`. See [JDK Tooling](https://github.com/redhat-developer/vscode-java/#java-tooling-jdk) for details.
 
 ## Supported VS Code settings
 

--- a/src/languageServer/javaServerStarter.ts
+++ b/src/languageServer/javaServerStarter.ts
@@ -15,7 +15,7 @@ export function prepareExecutable(requirements: RequirementsData, microprofileJa
   const options: ExecutableOptions = Object.create(null);
   options.env = process.env;
   executable.options = options;
-  executable.command = path.resolve(requirements.java_home + '/bin/java');
+  executable.command = path.resolve(requirements.tooling_jre + '/bin/java');
   executable.args = prepareParams(microprofileJavaExtensions);
   return executable;
 }

--- a/src/languageServer/requirements.ts
+++ b/src/languageServer/requirements.ts
@@ -7,10 +7,13 @@ import { Uri, workspace } from 'vscode';
 
 import * as expandHomeDir from 'expand-home-dir';
 import * as findJavaHome from 'find-java-home';
+import { JavaExtensionAPI } from '../extension';
 const isWindows = process.platform.indexOf('win') === 0;
 const JAVA_FILENAME = 'java' + (isWindows?'.exe': '');
 
 export interface RequirementsData {
+    tooling_jre: string;
+    tooling_jre_version: number;
     java_home: string;
     java_version: number;
 }
@@ -22,10 +25,17 @@ export interface RequirementsData {
  * if any of the requirements fails to resolve.
  *
  */
-export async function resolveRequirements(): Promise<RequirementsData> {
+export async function resolveRequirements(api: JavaExtensionAPI): Promise<RequirementsData> {
+
+    // Use the embedded JRE from 'redhat.java' if it exists
+    const requirementsData = api.javaRequirement;
+    if (requirementsData) {
+        return Promise.resolve(requirementsData);
+    }
+
     const javaHome = await checkJavaRuntime();
     const javaVersion = await checkJavaVersion(javaHome);
-    return Promise.resolve({ java_home: javaHome, java_version: javaVersion});
+    return Promise.resolve({tooling_jre: javaHome, tooling_jre_version: javaVersion, java_home: javaHome, java_version: javaVersion});
 }
 
 function checkJavaRuntime(): Promise<string> {

--- a/src/util/javaServerMode.ts
+++ b/src/util/javaServerMode.ts
@@ -1,6 +1,7 @@
-import { extensions, window, commands } from "vscode";
+import { window, commands } from "vscode";
+import { JavaExtensionAPI } from "../extension";
 
-const JAVA_EXTENSION_ID = "redhat.java";
+export const JAVA_EXTENSION_ID = "redhat.java";
 
 export enum ServerMode {
   STANDARD = "Standard",
@@ -13,17 +14,7 @@ export enum ServerMode {
  * Before activating Tools for MicroProfile.
  * If java ls was started in lightweight mode, It will prompt user to switch
  */
-export async function waitForStandardMode(): Promise<void>  {
-  const vscodeJava = extensions.getExtension(JAVA_EXTENSION_ID);
-  if (!vscodeJava) {
-    throw new Error("VSCode java is not installed");
-  }
-
-  const api = await vscodeJava.activate();
-  if (!api) {
-    throw new Error("VSCode java api not found");
-  }
-
+export async function waitForStandardMode(api: JavaExtensionAPI): Promise<void>  {
   // If hybrid, standard mode is being launched. Wait for standard mode then resolve.
   if (api.serverMode === ServerMode.HYBRID) {
     return new Promise((resolve) => {


### PR DESCRIPTION
- Fixes #84
- Use 'redhat.java' embedded JRE through RequirementsData from its
  ExtensionAPI
- Adjust README with new requirements

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>