### PR TITLE
Include smallrye-common-expression bundles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ const microprofileServerDir = '../lsp4mp/microprofile.ls/org.eclipse.lsp4mp.ls';
 
 const microprofileExtensionDir = '../lsp4mp/microprofile.jdt';
 const microprofileExtension = 'org.eclipse.lsp4mp.jdt.core';
-
+const microprofileSite = 'org.eclipse.lsp4mp.jdt.site';
 
 gulp.task('buildServer', (done) => {
   cp.execSync(mvnw() + ' clean install -DskipTests', { cwd: microprofileServerDir , stdio: 'inherit' });
@@ -30,9 +30,23 @@ gulp.task('buildServer', (done) => {
 });
 
 gulp.task('buildExtension', (done) => {
-  cp.execSync(mvnw() + ' -pl "' + microprofileExtension + '" clean verify -DskipTests', { cwd: microprofileExtensionDir, stdio: 'inherit' });
+  cp.execSync(mvnw() + ' clean verify -DskipTests', { cwd: microprofileExtensionDir, stdio: 'inherit' });
   gulp.src(microprofileExtensionDir + '/' + microprofileExtension + '/target/' + microprofileExtension + '-!(*sources).jar')
     .pipe(rename(microprofileExtension + '.jar'))
+    .pipe(gulp.dest('./jars'));
+  gulp.src(microprofileExtensionDir + '/' + microprofileSite + '/target/repository/plugins/wrapped*.jar')
+    .pipe(rename(function (path, _file) {
+      const patt = /wrapped\.([^_]+).*/;
+      const result = path.basename.match(patt);
+      path.basename = result[1];
+    }))
+    .pipe(gulp.dest('./jars'));
+  gulp.src(microprofileExtensionDir + '/' + microprofileSite + '/target/repository/plugins/org.jboss.logging*.jar')
+    .pipe(rename(function (path, _file) {
+      const patt = /([^_]+).*/;
+      const result = path.basename.match(patt);
+      path.basename = result[1];
+    }))
     .pipe(gulp.dest('./jars'));
   done();
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,11 @@
   ],
   "contributes": {
     "javaExtensions": [
-      "./jars/org.eclipse.lsp4mp.jdt.core.jar"
+      "./jars/org.eclipse.lsp4mp.jdt.core.jar",
+      "./jars/io.smallrye.common.smallrye-common-constraint.jar",
+      "./jars/io.smallrye.common.smallrye-common-expression.jar",
+      "./jars/io.smallrye.common.smallrye-common-function.jar",
+      "./jars/org.jboss.logging.jboss-logging.jar"
     ],
     "jsonValidation": [
       {


### PR DESCRIPTION
Modifies the script that builds the JDT.LS extension in order to adapt to the inclusion of smallrye-common-expression and a custom target platform in lsp4mp.

Requires eclipse/lsp4mp#283

Signed-off-by: David Thompson <davthomp@redhat.com>
