### PR TITLE
Don't throw an error popup when MicroProfile LS cancel the inlay hint process

### DIFF
--- a/src/providers/microprofileInlayHintsProvider.ts
+++ b/src/providers/microprofileInlayHintsProvider.ts
@@ -25,6 +25,9 @@ export class MicroprofileInlayHintsProvider implements InlayHintsProvider {
       }
       return asInlayHints(values, this.client);
     } catch (error) {
+      if (token.isCancellationRequested) {
+        return [];
+      }
       return this.client.handleFailedRequest(InlayHintRequest.type, token, error);
     }
   }


### PR DESCRIPTION
Don't throw an error popup when MicroProfile LS cancel the inlay hint process.

Signed-off-by: azerr azerr@redhat.com