### PR TITLE
Documentation on hover for properties in properties files

### DIFF
--- a/src/definitions/microProfileLSRequestNames.ts
+++ b/src/definitions/microProfileLSRequestNames.ts
@@ -17,6 +17,7 @@
 // MicroProfile language server request and notifications
 export const PROJECT_INFO_REQUEST = 'microprofile/projectInfo';
 export const PROPERTY_DEFINITION_REQUEST = 'microprofile/propertyDefinition';
+export const PROPERTY_DOCUMENTATION_REQUEST = 'microprofile/propertyDocumentation';
 export const JSON_SCHEMA_FOR_PROJECT_INFO_REQUEST = 'microprofile/jsonSchemaForProjectInfo';
 export const JAVA_CODEACTION_RESOLVE_REQUEST = 'microprofile/java/codeActionResolve';
 export const JAVA_CODEACTION_REQUEST = 'microprofile/java/codeAction';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,7 @@ async function doActivate(context: ExtensionContext) {
      */
     bindRequest(MicroProfileLS.PROJECT_INFO_REQUEST);
     bindRequest(MicroProfileLS.PROPERTY_DEFINITION_REQUEST);
+    bindRequest(MicroProfileLS.PROPERTY_DOCUMENTATION_REQUEST);
     bindRequest(MicroProfileLS.JAVA_CODEACTION_REQUEST);
     bindRequest(MicroProfileLS.JAVA_CODEACTION_RESOLVE_REQUEST);
     bindRequest(MicroProfileLS.JAVA_CODELENS_REQUEST);


### PR DESCRIPTION
Bind the "microprofile/propertyDocumentation" command so that documentation appears when hovering over property keys in properties files.

See eclipse/lsp4mp#329

Signed-off-by: David Thompson <davthomp@redhat.com>
