### PR TITLE
Telemetry for code actions

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -7,6 +7,9 @@ vscode-microprofile has opt-in telemetry collection, provided by [vscode-redhat-
 vscode-microprofile emits telemetry events when the extension starts and stops,
 which contain the common data mentioned on the [vscode-redhat-telemetry page](https://github.com/redhat-developer/vscode-redhat-telemetry/blob/HEAD/USAGE_DATA.md#common-data).
 
+vscode-microprofile emits telemetry events whenever you apply a quick fix or source action,
+and emits an event if applying the quick fix or source action fails.
+
 ## How to opt in or out
 
 Use the `redhat.telemetry.enabled` setting in order to enable or disable telemetry collection.

--- a/src/definitions/commands.ts
+++ b/src/definitions/commands.ts
@@ -14,3 +14,5 @@
  * limitations under the License.
  */
 export const RELOAD_WINDOW = 'workbench.action.reloadWindow';
+
+export const APPLY_CODE_ACTION_WITH_TELEMETRY = 'microprofile.applyCodeAction';

--- a/src/util/telemetry.ts
+++ b/src/util/telemetry.ts
@@ -1,0 +1,24 @@
+import { TelemetryService } from "@redhat-developer/vscode-redhat-telemetry/lib";
+
+const CODE_ACTION_TELEMETRY_EVENT = 'codeAction';
+const SUCCEED_VALUE = "succeeded";
+const FAIL_VALUE = "failed";
+
+/**
+ * Sends a telemetry event to indicate that the given code action was applied.
+ *
+ * @param telemetryService the telemetry service
+ * @param codeActionId the id of the type of code action (not the name, since that might contain context such as variable names)
+ * @param succeeded true if the code action was applied successfully, and false otherwise
+ * @param error the error message if the code action has failed
+ */
+export async function sendCodeActionTelemetry(telemetryService: TelemetryService, codeActionId: string, succeeded: boolean, error?) {
+  telemetryService.send({
+    name: CODE_ACTION_TELEMETRY_EVENT,
+    properties: {
+      codeActionId: codeActionId,
+      status: succeeded ? SUCCEED_VALUE : FAIL_VALUE,
+      error_message: error ? `${error}` : undefined
+    }
+  });
+}


### PR DESCRIPTION
- Send telemetry every time a quick fix or source action is applied
- Use the new code action id field introduced in https://github.com/eclipse/lsp4mp/pull/371 to identify the type of code action in the telemetry message so that we can gauge usage of each code action

Requires https://github.com/eclipse/lsp4mp/pull/371

Signed-off-by: David Thompson <davthomp@redhat.com>
