### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  groups:
+    typescript-eslint:
+      patterns:
+      - "@typescript-eslint/*"


### PR DESCRIPTION
Configures dependabot to create PRs that update npm dependencies.

Signed-off-by: David Thompson <davthomp@redhat.com>
