### PR TITLE
Set encoding as false for gulp.src to treat content as binary.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,24 +25,24 @@ const microprofileSite = 'org.eclipse.lsp4mp.jdt.site';
 
 gulp.task('buildServer', (done) => {
   cp.execSync(mvnw() + ' clean install -B -DskipTests', { cwd: microprofileServerDir , stdio: 'inherit' });
-  gulp.src(microprofileServerDir + '/target/' + microprofileServerName)
+  gulp.src(microprofileServerDir + '/target/' + microprofileServerName, { encoding: false })
     .pipe(gulp.dest('./server'));
   done();
 });
 
 gulp.task('buildExtension', (done) => {
   cp.execSync(mvnw() + ' clean verify -B -DskipTests', { cwd: microprofileExtensionDir, stdio: 'inherit' });
-  gulp.src(microprofileExtensionDir + '/' + microprofileExtension + '/target/' + microprofileExtension + '-!(*sources).jar')
+  gulp.src(microprofileExtensionDir + '/' + microprofileExtension + '/target/' + microprofileExtension + '-!(*sources).jar', { encoding: false })
     .pipe(rename(microprofileExtension + '.jar'))
     .pipe(gulp.dest('./jars'));
-  gulp.src(microprofileExtensionDir + '/' + microprofileSite + '/target/repository/plugins/wrapped*.jar')
+  gulp.src(microprofileExtensionDir + '/' + microprofileSite + '/target/repository/plugins/wrapped*.jar', { encoding: false })
     .pipe(rename(function (path, _file) {
       const patt = /wrapped\.([^_]+).*/;
       const result = path.basename.match(patt);
       path.basename = result[1];
     }))
     .pipe(gulp.dest('./jars'));
-  gulp.src(microprofileExtensionDir + '/' + microprofileSite + '/target/repository/plugins/org.jboss.logging*.jar')
+  gulp.src(microprofileExtensionDir + '/' + microprofileSite + '/target/repository/plugins/org.jboss.logging*.jar', { encoding: false })
     .pipe(rename(function (path, _file) {
       const patt = /([^_]+).*/;
       const result = path.basename.match(patt);


### PR DESCRIPTION
All jars passing through `gulp.src` are corrupted. I noticed that pre-release bulds were failing for vscode-quarkus & vscode-microprofile. When I examined the actual logs, I was seeing :

```
!ENTRY org.eclipse.jdt.ls.core 4 0 2024-05-02 16:27:12.411
!MESSAGE Failed to load extension bundles
!STACK 1
org.eclipse.core.runtime.CoreException: Load bundle list
    at org.eclipse.jdt.ls.core.internal.handlers.BundleUtils.loadBundles(BundleUtils.java:173)
...
...
Contains: Cannot extract bundle symbolicName or version /home/rgrunber/.vscode/extensions/redhat.vscode-microprofile-0.12.2024041608/jars/org.eclipse.lsp4mp.jdt.core.jar
java.util.zip.ZipException: zip END header not found
    at java.base/java.util.zip.ZipFile$Source.findEND(Unknown Source)
    at java.base/java.util.zip.ZipFile$Source.initCEN(Unknown Source)
    at java.base/java.util.zip.ZipFile$Source.<init>(Unknown Source)
    at java.base/java.util.zip.ZipFile$Source.get(Unknown Source)
    at java.base/java.util.zip.ZipFile$CleanableResource.<init>(Unknown Source)
    at java.base/java.util.zip.ZipFile.<init>(Unknown Source)
    at java.base/java.util.zip.ZipFile.<init>(Unknown Source)
    at java.base/java.util.jar.JarFile.<init>(Unknown Source)
    at java.base/java.util.jar.JarFile.<init>(Unknown Source)
    at java.base/java.util.jar.JarFile.<init>(Unknown Source)
    at org.eclipse.jdt.ls.core.internal.handlers.BundleUtils.getBundleInfo(BundleUtils.java:328)
    at org.eclipse.jdt.ls.core.internal.handlers.BundleUtils.loadBundles(BundleUtils.java:120)
    at org.eclipse.jdt.ls.core.internal.handlers.InitHandler.handleInitializationOptions(InitHandler.java:114)
    at org.eclipse.jdt.ls.core.internal.handlers.BaseInitHandler.initialize(BaseInitHandler.java:64)
    at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.initialize(JDTLanguageServer.java:284)
```

When I examined the jars, I noticed they appear to be corrupted. At first I thought it was the build process but then realized it was Gulp 5 (https://github.com/redhat-developer/vscode-microprofile/pull/196). Tracked down https://github.com/gulpjs/gulp/issues/2797 and the workaround seems to work.