### PR TITLE
Implement post-release version bump.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Build & Release VS Code MicroProfile
 
 on:
   schedule:
@@ -156,3 +156,21 @@ jobs:
         if: ${{ github.event_name == 'schedule' || inputs.publishToOVSX == 'true' || inputs.publishPreRelease == 'true' }}
         run: |
           ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }}  --packagePath vscode-microprofile/vscode-microprofile-*-${GITHUB_RUN_NUMBER}.vsix
+  post-release-job:
+    if: ${{ inputs.publishToMarketPlace == 'true' && inputs.publishToOVSX == 'true' }}
+    runs-on: ubuntu-latest
+    needs: release-job
+    steps:
+      - name: Check Out VS Code MicroProfile
+        uses: actions/checkout@v4
+      - name: Set Up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Upversion for Development
+        run: |
+          tag=`npm version --no-git-tag-version patch`
+          git config --global user.email "vscode-microprofile-bot@users.noreply.github.com"
+          git config --global user.name "vscode-microprofile-bot"
+          git commit -am "Upversion to ${tag#v}"
+          git push origin


### PR DESCRIPTION
- Improve naming of the 'release' workflow.

@angelozerr , Let me know if the name works for you. This will also handle post-release bumps, simplifying the release instructions. I can do the same for vscode-quarkus and any other vscode extensions we release. `pm version --no-git-tag-version patch` makes it really easy!