### PR TITLE
Fix dependabot cron expression

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: cron
-    cronjob: 0 0 8 * * 2,4 *
+    cronjob: 0 8 * * 2,4
   open-pull-requests-limit: 10
   groups:
     typescript-eslint:


### PR DESCRIPTION
It only accepts a 5 part expression, and I supplied a 7 part one.