### PR TITLE
Surround cron expression for dependabot in doublequotes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: cron
-    cronjob: 0 8 * * 2,4
+    cronjob: "0 8 * * 2,4"
   open-pull-requests-limit: 10
   groups:
     typescript-eslint:


### PR DESCRIPTION
It may have been treated as a two element list instead of string