### PR TITLE
Group eslint dependencies together

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,7 @@ updates:
     cronjob: "0 8 * * 2,4"
   open-pull-requests-limit: 10
   groups:
-    typescript-eslint:
+    eslint:
       patterns:
-      - "@typescript-eslint/*"
+        - "eslint"
+        - "@eslint/js"


### PR DESCRIPTION
- Remove typescript-eslint group; it's unused