### PR TITLE
Only run tests once on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The tests used to be run twice; once since it's a push event and once since it's a pull request. This change should make sure they only run once.